### PR TITLE
BR-31 - Corrigido erro ao listar professores não mostrar professores com admin

### DIFF
--- a/ifclass/src/main/java/com/ifclass/ifclass/usuario/controller/UsuarioController.java
+++ b/ifclass/src/main/java/com/ifclass/ifclass/usuario/controller/UsuarioController.java
@@ -47,6 +47,11 @@ public class UsuarioController {
         return service.listar();
     }
 
+    @GetMapping("/listar/professores")
+    public List<Usuario> listarProfessores() {
+        return service.listarProfessores();
+    }
+
     @GetMapping("/detalhes")
     public List<UsuarioDetalhesDTO> listarComDetalhes() {
         return service.listarComDetalhes();

--- a/ifclass/src/main/java/com/ifclass/ifclass/usuario/service/UsuarioService.java
+++ b/ifclass/src/main/java/com/ifclass/ifclass/usuario/service/UsuarioService.java
@@ -41,6 +41,10 @@ public class UsuarioService {
         return repository.findAllByAuthoritiesNotContaining("ROLE_ADMIN");
     }
 
+    public List<Usuario> listarProfessores() {
+        return repository.findByAuthoritiesContaining("ROLE_PROFESSOR");
+    }
+
     @Cacheable(value = "usuarios", key = "'detalhes'")
     public List<UsuarioDetalhesDTO> listarComDetalhes() {
         List<Usuario> usuarios = repository.findAllByAuthoritiesNotContaining("ROLE_ADMIN");


### PR DESCRIPTION
@matheus-phelipe 
@ArtTonon 

#5

Adicionado no backend o public listarProfessores, para que assim possa ser usado no frontend para poder listar todos os usuários com a permissão Professores (sem excessão) no momento que criar uma aula