### PR TITLE
BR-32 - Incluido botão adicionar usuário somente para Admin e formulario de criação de usuario

### DIFF
--- a/ifclass/src/main/java/com/ifclass/ifclass/usuario/controller/UsuarioController.java
+++ b/ifclass/src/main/java/com/ifclass/ifclass/usuario/controller/UsuarioController.java
@@ -47,6 +47,11 @@ public class UsuarioController {
         return service.listar();
     }
 
+    @GetMapping("/listar/professores")
+    public List<Usuario> listarProfessores() {
+        return service.listarProfessores();
+    }
+
     @GetMapping("/detalhes")
     public List<UsuarioDetalhesDTO> listarComDetalhes() {
         return service.listarComDetalhes();

--- a/ifclass/src/main/java/com/ifclass/ifclass/usuario/service/UsuarioService.java
+++ b/ifclass/src/main/java/com/ifclass/ifclass/usuario/service/UsuarioService.java
@@ -41,6 +41,10 @@ public class UsuarioService {
         return repository.findAllByAuthoritiesNotContaining("ROLE_ADMIN");
     }
 
+    public List<Usuario> listarProfessores() {
+        return repository.findByAuthoritiesContaining("ROLE_PROFESSOR");
+    }
+
     @Cacheable(value = "usuarios", key = "'detalhes'")
     public List<UsuarioDetalhesDTO> listarComDetalhes() {
         List<Usuario> usuarios = repository.findAllByAuthoritiesNotContaining("ROLE_ADMIN");

--- a/ifclass/src/main/java/com/ifclass/ifclass/usuario/service/UsuarioService.java
+++ b/ifclass/src/main/java/com/ifclass/ifclass/usuario/service/UsuarioService.java
@@ -98,13 +98,17 @@ public class UsuarioService {
         var encoder = new BCryptPasswordEncoder();
         usuario.setSenha(encoder.encode(usuario.getSenha()));
 
-        usuario.setAuthorities(Collections.singletonList(RoleUsuario.ROLE_ALUNO.toString()));
+        // Se o front não mandar authorities, define padrão ROLE_ALUNO
+        if (usuario.getAuthorities() == null || usuario.getAuthorities().isEmpty()) {
+            usuario.setAuthorities(Collections.singletonList(RoleUsuario.ROLE_ALUNO.toString()));
+        }
 
         repository.save(usuario);
         usuario.setSenha(null);
 
         return usuario;
     }
+
 
     @CacheEvict(value = "usuarios", allEntries = true)
     public void excluir(Long id) {


### PR DESCRIPTION
@matheus-phelipe 
@ArtTonon 

#11

Foi adicionado uma condição no arquivo UsuarioService.java para ajustar a criação de usuarios sem que eles recebam a permissão Role_Aluno de cara, fazendo assim com que cada usuário seja criado com a permissão selecionada no modal de criação de usuario.